### PR TITLE
Downgrade python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-13]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
           - operating-system: ubuntu-latest
             path: ~/.cache/pip
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/google_docstring_parser/__init__.py
+++ b/google_docstring_parser/__init__.py
@@ -3,6 +3,6 @@
 A lightweight, efficient parser for Google-style Python docstrings that converts them into structured dictionaries.
 """
 
-from google_docstring_parser.parser import parse_google_docstring
+from google_docstring_parser.docstring_parser import parse_google_docstring
 
 __all__ = ["parse_google_docstring"]

--- a/google_docstring_parser/docstring_parser.py
+++ b/google_docstring_parser/docstring_parser.py
@@ -16,6 +16,8 @@ This module provides functions to parse Google-style docstrings into structured 
 # See the LICENSE file for complete details.
 """
 
+from __future__ import annotations
+
 import re
 from typing import Any
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = { text = "Custom License - See LICENSE file for details" }
 maintainers = [ { name = "Vladimir Iglovikov" } ]
 
 authors = [ { name = "Vladimir Iglovikov" } ]
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -24,6 +24,7 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -33,6 +34,10 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Typing :: Typed",
+]
+
+dependencies = [
+  "typing-extensions>=4.9; python_version<'3.10'",
 ]
 
 optional-dependencies.dev = [
@@ -51,7 +56,7 @@ google_docstring_parser = [ "*.md" ]
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
-target-version = "py310"
+target-version = "py39"
 
 line-length = 120
 indent-width = 4
@@ -123,7 +128,7 @@ lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 lint.pydocstyle.convention = "google"
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.9"
 ignore_missing_imports = true
 follow_imports = "silent"
 warn_redundant_casts = true

--- a/tests/test_docstring_checker/test_docstring_validation.py
+++ b/tests/test_docstring_checker/test_docstring_validation.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Any, Dict
+from typing import Any
 
 import pytest
 
@@ -68,7 +68,7 @@ from google_docstring_parser import parse_google_docstring
         ),
     ],
 )
-def test_validate_docstring(docstring: str, expected_errors: List[str]) -> None:
+def test_validate_docstring(docstring: str, expected_errors: list[str]) -> None:
     """Test the validate_docstring function with various docstrings."""
     errors = validate_docstring(docstring)
     assert errors == expected_errors
@@ -130,7 +130,7 @@ def test_validate_docstring(docstring: str, expected_errors: List[str]) -> None:
         ),
     ],
 )
-def test_check_param_types(docstring_dict: Dict[str, Any], require_types: bool, expected_errors: List[str]) -> None:
+def test_check_param_types(docstring_dict: dict[str, Any], require_types: bool, expected_errors: list[str]) -> None:
     """Test the check_param_types function with various docstring dictionaries."""
     errors = check_param_types(docstring_dict, require_types)
     assert errors == expected_errors

--- a/tests/test_docstring_checker/test_docstring_validation.py
+++ b/tests/test_docstring_checker/test_docstring_validation.py
@@ -1,8 +1,8 @@
 """Tests for the docstring validation functions."""
+from __future__ import annotations
 
-import ast
 from pathlib import Path
-from typing import List, Tuple, Any, Dict
+from typing import List, Any, Dict
 
 import pytest
 

--- a/tests/test_docstring_checker/test_example_files.py
+++ b/tests/test_docstring_checker/test_example_files.py
@@ -1,4 +1,5 @@
 """Tests for checking docstrings in the example files."""
+from __future__ import annotations
 
 from pathlib import Path
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import pytest
 from typing import Any
 
-from google_docstring_parser.parser import parse_google_docstring, _parse_args_section
+from google_docstring_parser.docstring_parser import parse_google_docstring, _parse_args_section
 
 @pytest.mark.parametrize(
     "docstring,expected",

--- a/tools/check_docstrings.py
+++ b/tools/check_docstrings.py
@@ -4,6 +4,7 @@
 This script scans Python files in specified directories and checks if their
 docstrings can be parsed with the google_docstring_parser.
 """
+from __future__ import annotations
 
 import argparse
 import ast


### PR DESCRIPTION
## Summary by Sourcery

Lower the minimum supported Python version to 3.9 and update the CI configuration and metadata accordingly. This change also introduces a dependency on `typing-extensions` for Python versions less than 3.10.

CI:
- Add Python 3.9 to the CI matrix.
- Update CI configuration to use Python 3.9 as the minimum version.