### PR TITLE
Fix in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,13 +49,13 @@ repos:
       - id: codespell
         additional_dependencies: ["tomli"]
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "v2.5.1"
+    rev: "v2.6.0"
     hooks:
       - id: pyproject-fmt
         additional_dependencies: ["tomli"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.2
+    rev: v0.11.10
     hooks:
       # Run the linter with configuration from pyproject.toml
       - id: ruff

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,10 @@
   name: Check Google-style docstrings can be parsed
   description: >
     Checks that Google-style docstrings in specified folders can be parsed with google_docstring_parser.
-    Configured via pyproject.toml under [tool.docstring_checker] section.
+    IMPORTANT: You MUST configure paths in pyproject.toml under [tool.docstring_checker] section,
+    otherwise no files will be checked. For example:
+    [tool.docstring_checker]
+    paths = ["your_package", "your_module"]
   entry: python -m tools.check_docstrings
   language: python
   types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=45", "wheel" ]
 
 [project]
 name = "google-docstring-parser"
-version = "0.0.7"
+version = "0.0.8"
 
 description = "A lightweight, efficient parser for Google-style Python docstrings that converts them into structured dictionaries."
 readme = "README.md"

--- a/tests/test_docstring_checker/test_check_docstrings.py
+++ b/tests/test_docstring_checker/test_check_docstrings.py
@@ -355,3 +355,135 @@ def test_returns_validation(code: str, expected_returncode: int, expected_output
     assert result.returncode == expected_returncode
     if expected_output:
         assert expected_output in result.stdout
+
+
+def test_no_paths_specified(tmp_path: Path) -> None:
+    """Test that the checker handles the case when no paths are specified.
+
+    Args:
+        tmp_path (Path): Temporary directory fixture
+    """
+    # Create a dummy Python file that would cause errors if checked
+    test_file = tmp_path / "test_file.py"
+    test_file.write_text('''
+def missing_docstring_function(param1):
+    # This function has no docstring and would fail checks
+    return None
+''')
+
+    # Create an empty pyproject.toml to test with no configuration
+    empty_pyproject = tmp_path / "pyproject.toml"
+    empty_pyproject.write_text('''
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+''')
+
+    # Get the path to the module we're testing
+    project_root = Path(__file__).parent.parent.parent
+    tools_module = project_root / "tools" / "check_docstrings.py"
+
+    # Set up environment so imports work
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(project_root)
+
+    # Run the checker with the configuration
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(tools_module),
+        ],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    # Check that the command succeeds (exits with code 0)
+    assert result.returncode == 0, f"Checker should succeed when no paths are specified, got stdout: {result.stdout}, stderr: {result.stderr}"
+
+    # Check that the output contains the expected message
+    assert "No paths specified for checking" in result.stdout, "Should show message about no paths specified"
+
+
+def test_configured_paths(tmp_path: Path) -> None:
+    """Test that the checker uses paths configured in pyproject.toml.
+
+    Args:
+        tmp_path (Path): Temporary directory fixture
+    """
+    # Create a directory structure
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+
+    # Create a file with an error in the src directory
+    src_file = src_dir / "file.py"
+    src_file.write_text('''
+def function_with_error(param1):
+    """Function with missing parameter type.
+
+    Args:
+        param1: Parameter without a type
+
+    Returns:
+        None
+    """
+    return None
+''')
+
+    # Create another file outside of src directory
+    other_file = tmp_path / "other.py"
+    other_file.write_text('''
+def another_function(param1):
+    """Function with missing parameter type.
+
+    Args:
+        param1: Parameter without a type
+
+    Returns:
+        None
+    """
+    return None
+''')
+
+    # Create a pyproject.toml that only includes the src directory
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('''
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.docstring_checker]
+paths = ["src"]
+require_param_types = true
+''')
+
+    # Get the path to the module we're testing
+    project_root = Path(__file__).parent.parent.parent
+    tools_module = project_root / "tools" / "check_docstrings.py"
+
+    # Copy the google_docstring_parser module to the tmp_path for imports to work
+    # This is a simplified approach for testing - we'll use PYTHONPATH to make imports work
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(project_root)
+
+    # Run the checker with the configuration
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(tools_module),
+            "--verbose",
+        ],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    # It should fail because the src/file.py has a docstring error
+    assert result.returncode == 1, f"Checker should fail when errors are found, output: {result.stdout}, error: {result.stderr}"
+
+    # The error should be about the file in src, not the one outside
+    assert "src/file.py" in result.stdout, f"Error should be from src/file.py, got stdout: {result.stdout}, stderr: {result.stderr}"
+    assert "other.py" not in result.stdout, "Error should not include other.py"
+    assert "Parameter 'param1' is missing a type" in result.stdout, "Should detect missing parameter type"

--- a/tests/test_docstring_checker/test_check_docstrings.py
+++ b/tests/test_docstring_checker/test_check_docstrings.py
@@ -484,6 +484,8 @@ require_param_types = true
     assert result.returncode == 1, f"Checker should fail when errors are found, output: {result.stdout}, error: {result.stderr}"
 
     # The error should be about the file in src, not the one outside
-    assert "src/file.py" in result.stdout, f"Error should be from src/file.py, got stdout: {result.stdout}, stderr: {result.stderr}"
+    # Use os.path.join to create a platform-specific path for comparison
+    # or check for path components separately to be platform-agnostic
+    assert "src" in result.stdout and "file.py" in result.stdout, f"Error should be from src/file.py, got stdout: {result.stdout}, stderr: {result.stderr}"
     assert "other.py" not in result.stdout, "Error should not include other.py"
     assert "Parameter 'param1' is missing a type" in result.stdout, "Should detect missing parameter type"

--- a/tools/check_docstrings.py
+++ b/tools/check_docstrings.py
@@ -22,7 +22,7 @@ from google_docstring_parser.google_docstring_parser import (
 
 # Default configuration
 DEFAULT_CONFIG = {
-    "paths": ["."],
+    "paths": [],  # Empty by default, so no directories are scanned unless explicitly specified
     "require_param_types": False,
     "check_references": True,
     "exclude_files": [],
@@ -702,6 +702,14 @@ def main() -> None:
         print(f"  Require parameter types: {require_param_types}")
         print(f"  Check references: {check_references}")
         print(f"  Exclude files: {exclude_files}")
+
+    # Check if paths is empty
+    if not paths:
+        print(
+            "No paths specified for checking. Please specify paths as command line "
+            "arguments or configure them in pyproject.toml under [tool.docstring_checker] section.",
+        )
+        sys.exit(0)
 
     if all_errors := _process_paths(
         paths,


### PR DESCRIPTION
## Summary by Sourcery

Introduce explicit path configuration for the docstring checker, update default behavior to skip scanning when no paths are provided, add corresponding tests, clarify pre-commit documentation, and bump related tool and project versions.

Enhancements:
- Require explicit paths for docstring checking by default and exit gracefully with a message when none are specified

CI:
- Upgrade pyproject-fmt to v2.6.0 and ruff to v0.11.10 in pre-commit configuration

Documentation:
- Clarify in .pre-commit-hooks.yaml that paths must be configured in pyproject.toml

Tests:
- Add tests for handling no paths specified and using configured paths

Chores:
- Bump project version to 0.0.8